### PR TITLE
Rename 'mocks' packages to 'testhelper'

### DIFF
--- a/backend/demo/backend_test.go
+++ b/backend/demo/backend_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/cceckman/discoirc/backend/demo"
-	"github.com/cceckman/discoirc/backend/mocks"
+	"github.com/cceckman/discoirc/backend/testhelper"
 	"github.com/cceckman/discoirc/data"
 )
 
@@ -33,7 +33,7 @@ func TestSubscribeFiltered(t *testing.T) {
 	b.TickChannel(sonnet.Net, "#one90one")
 	b.TickMessages(sonnet.Net, "#one90one")
 
-	ch := mocks.NewChannel(eighteen.Net, eighteen.Name)
+	ch := testhelper.NewChannel(eighteen.Net, eighteen.Name)
 
 	b.Subscribe(ch)
 
@@ -121,7 +121,7 @@ func TestSubscribe_FromUI(t *testing.T) {
 	b.TickMessages(eighteen.Net, eighteen.Name)
 	b.TickNetwork("botnet")
 
-	c := mocks.NewClient()
+	c := testhelper.NewClient()
 
 	// Run subscribe in the UI thread, make sure we don't get a race.
 	c.Join(func() {
@@ -145,7 +145,7 @@ func TestSubscribe_FromUI(t *testing.T) {
 func TestChannelCallback(t *testing.T) {
 	attempts := 4
 	b := demo.New()
-	c := mocks.NewChannel(eighteen.Net, eighteen.Name)
+	c := testhelper.NewChannel(eighteen.Net, eighteen.Name)
 
 	c.Archive = b
 	b.Subscribe(c)
@@ -180,7 +180,7 @@ func TestSubscribe_Resubscribe(t *testing.T) {
 	// Initialize data: one network
 	b.TickMessages(eighteen.Net, eighteen.Name)
 
-	c1 := mocks.NewClient()
+	c1 := testhelper.NewClient()
 	go b.Subscribe(c1)
 
 	for i, done := 0, false; !(done || i > attempts); i = delay(i) {
@@ -194,7 +194,7 @@ func TestSubscribe_Resubscribe(t *testing.T) {
 		})
 	}
 
-	c2 := mocks.NewClient()
+	c2 := testhelper.NewClient()
 	go b.Subscribe(c2)
 
 	b.TickMessages("botnet", "#eighteen")
@@ -220,7 +220,7 @@ func TestSubscribe_Resubscribe(t *testing.T) {
 func TestSend(t *testing.T) {
 	attempts := 4
 	b := demo.New()
-	c := mocks.NewChannel(eighteen.Net, eighteen.Name)
+	c := testhelper.NewChannel(eighteen.Net, eighteen.Name)
 
 	c.Archive = b
 	b.Subscribe(c)
@@ -246,4 +246,3 @@ func TestSend(t *testing.T) {
 		})
 	}
 }
-

--- a/backend/testhelper/channel.go
+++ b/backend/testhelper/channel.go
@@ -1,4 +1,4 @@
-package mocks
+package testhelper
 
 import (
 	"github.com/cceckman/discoirc/backend"

--- a/backend/testhelper/client.go
+++ b/backend/testhelper/client.go
@@ -1,5 +1,5 @@
 // Package mocks provides mocks to use for testing backends.
-package mocks
+package testhelper
 
 import (
 	"github.com/cceckman/discoirc/backend"

--- a/backend/testhelper/client.go
+++ b/backend/testhelper/client.go
@@ -1,4 +1,4 @@
-// Package mocks provides mocks to use for testing backends.
+// Package testhelper provides mocks to use for testing backends.
 package testhelper
 
 import (

--- a/ui/channel/view_test.go
+++ b/ui/channel/view_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cceckman/discoirc/data"
 	"github.com/cceckman/discoirc/ui/channel"
-	"github.com/cceckman/discoirc/ui/mocks"
+	"github.com/cceckman/discoirc/ui/testhelper"
 
 	"github.com/marcusolsson/tui-go"
 )
@@ -67,7 +67,7 @@ var renderTests = []struct {
 				Topic:       "Act I, Scene 1",
 				Unread:      3834, // depending on your editor, of course.
 				Members:     12,   // in the company, more characters.
-				LastMessage: mocks.Events[len(mocks.Events)-1].Seq(),
+				LastMessage: testhelper.Events[len(testhelper.Events)-1].Seq(),
 			})
 		},
 		wantContents:    wantContents40x10,
@@ -91,7 +91,7 @@ var renderTests = []struct {
 				Topic:       "Act I, Scene 1",
 				Unread:      3834, // depending on your editor, of course.
 				Members:     12,   // in the company, more characters.
-				LastMessage: mocks.Events[len(mocks.Events)-1].Seq(),
+				LastMessage: testhelper.Events[len(testhelper.Events)-1].Seq(),
 			})
 
 			c.Resize(image.Pt(80, 80))
@@ -117,7 +117,7 @@ var renderTests = []struct {
 				Topic:       "Act I, Scene 1",
 				Unread:      3834, // depending on your editor, of course.
 				Members:     12,   // in the company, more characters.
-				LastMessage: mocks.Events[3].Seq(),
+				LastMessage: testhelper.Events[3].Seq(),
 			})
 		},
 		wantContents: `
@@ -142,8 +142,8 @@ func TestRender(t *testing.T) {
 			surface := tui.NewTestSurface(40, 10)
 			p := tui.NewPainter(surface, theme)
 
-			ui := mocks.NewController()
-			d := mocks.NewBackend()
+			ui := testhelper.NewController()
+			d := testhelper.NewBackend()
 
 			// Root creation must happen in the main thread
 			w := channel.New(data.Scope{Net: "HamNet", Name: "#hamlet"}, ui, d)
@@ -171,8 +171,8 @@ func testRenderer(e data.Event) tui.Widget {
 }
 
 func TestInput_Message(t *testing.T) {
-	ui := mocks.NewController()
-	d := mocks.NewBackend()
+	ui := testhelper.NewController()
+	d := testhelper.NewBackend()
 	_ = channel.New(data.Scope{Net: "HamNet", Name: "#hamlet"}, ui, d)
 
 	ui.Type("hello everyone")
@@ -188,8 +188,8 @@ func TestInput_Message(t *testing.T) {
 }
 
 func TestInput_QuitMessage(t *testing.T) {
-	ui := mocks.NewController()
-	d := mocks.NewBackend()
+	ui := testhelper.NewController()
+	d := testhelper.NewBackend()
 	_ = channel.New(data.Scope{Net: "HamNet", Name: "#hamlet"}, ui, d)
 
 	ui.Type("/quit nothing to see here\n")
@@ -203,8 +203,8 @@ func TestInput_QuitMessage(t *testing.T) {
 }
 
 func TestInput_QuitKeybind(t *testing.T) {
-	ui := mocks.NewController()
-	d := mocks.NewBackend()
+	ui := testhelper.NewController()
+	d := testhelper.NewBackend()
 	_ = channel.New(data.Scope{Net: "HamNet", Name: "#hamlet"}, ui, d)
 
 	ui.Root.OnKeyEvent(tui.KeyEvent{
@@ -221,17 +221,17 @@ func TestInput_QuitKeybind(t *testing.T) {
 }
 
 func TestInput_ActivateClient(t *testing.T) {
-	ui := mocks.NewController()
-	d := mocks.NewBackend()
+	ui := testhelper.NewController()
+	d := testhelper.NewBackend()
 
-	ui.V = mocks.ChannelView
+	ui.V = testhelper.ChannelView
 
 	// Root creation must happen in the main thread
 	_ = channel.New(data.Scope{Net: "HamNet", Name: "#hamlet"}, ui, d)
 
 	ui.Type("/client\n")
 
-	if ui.V != mocks.ClientView {
-		t.Errorf("unexpected root state: got: %v want: %v", ui.V, mocks.ClientView)
+	if ui.V != testhelper.ClientView {
+		t.Errorf("unexpected root state: got: %v want: %v", ui.V, testhelper.ClientView)
 	}
 }

--- a/ui/client/view_test.go
+++ b/ui/client/view_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cceckman/discoirc/data"
 	"github.com/cceckman/discoirc/ui/client"
-	discomocks "github.com/cceckman/discoirc/ui/mocks"
+	discomocks "github.com/cceckman/discoirc/ui/testhelper"
 )
 
 func TestNetwork_NoContents(t *testing.T) {

--- a/ui/controller_test.go
+++ b/ui/controller_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/cceckman/discoirc/ui"
 	"github.com/cceckman/discoirc/ui/channel"
 	"github.com/cceckman/discoirc/ui/client"
-	"github.com/cceckman/discoirc/ui/mocks"
+	"github.com/cceckman/discoirc/ui/testhelper"
 )
 
 func TestActivateChannel(t *testing.T) {
-	u := mocks.NewUI()
+	u := testhelper.NewUI()
 
-	ctl := ui.New(u, mocks.NewBackend())
+	ctl := ui.New(u, testhelper.NewBackend())
 
 	ctl.ActivateChannel("foonet", "#barchan")
 	if _, ok := u.Root.(*channel.View); !ok {
@@ -24,9 +24,9 @@ func TestActivateChannel(t *testing.T) {
 }
 
 func TestActivateClient(t *testing.T) {
-	u := mocks.NewUI()
+	u := testhelper.NewUI()
 
-	ctl := ui.New(u, mocks.NewBackend())
+	ctl := ui.New(u, testhelper.NewBackend())
 
 	ctl.ActivateClient()
 	if _, ok := u.Root.(client.View); !ok {
@@ -35,10 +35,10 @@ func TestActivateClient(t *testing.T) {
 }
 
 func TestEndToEnd(t *testing.T) {
-	u := mocks.NewUI()
+	u := testhelper.NewUI()
 	surface := tui.NewTestSurface(30, 10)
 	u.Painter = tui.NewPainter(surface, tui.NewTheme())
-	be := mocks.NewBackend()
+	be := testhelper.NewBackend()
 
 	ctl := ui.New(u, be)
 	ctl.ActivateClient()
@@ -50,7 +50,7 @@ func TestEndToEnd(t *testing.T) {
 		},
 		ChannelMode: "i",
 		Topic:       "The Battlements",
-		LastMessage: mocks.Events[2].Seq(),
+		LastMessage: testhelper.Events[2].Seq(),
 	}
 	net := data.NetworkState{
 		Scope: data.Scope{Net: "HamNet"},

--- a/ui/testhelper/controller.go
+++ b/ui/testhelper/controller.go
@@ -1,4 +1,4 @@
-package mocks
+package testhelper
 
 // NewController returns a mock Controller.
 func NewController() *Controller {

--- a/ui/testhelper/data.go
+++ b/ui/testhelper/data.go
@@ -1,4 +1,4 @@
-package mocks
+package testhelper
 
 import (
 	"github.com/cceckman/discoirc/backend"

--- a/ui/testhelper/ui.go
+++ b/ui/testhelper/ui.go
@@ -1,4 +1,4 @@
-package mocks
+package testhelper
 
 import (
 	"github.com/marcusolsson/tui-go"


### PR DESCRIPTION
They aren't mocks
(https://martinfowler.com/articles/mocksArentStubs.html#TheDifferenceBetweenMocksAndStubs),
though they were at one point in time (with Update in place). Don't use
a specific style for the test package, just use general term.