### PR TITLE
Add codecov.io badge & execution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
     echo "mode: count" > coverage.txt
     for pkg in $(go list ./... | grep -v /vendor/)
     do
-      go test -v -race -coverprofile=tmpcoverage.txt -covermode=atomic
+      go test -v -race -coverprofile=tmpcoverage.txt -covermode=atomic $pkg
       tail -n +2 tmpcoverage.txt >> coverage.txt
     done
   - go vet $(go list ./... | grep -v /vendor/)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Note: validate by running
+# gem install travis --no-rdoc --no-ri
+# travis lint .travis.yml
+
 language: go
 sudo: false
 go:
@@ -15,6 +19,9 @@ install:
   - go get github.com/golang/lint/golint
   - go get honnef.co/go/tools/cmd/megacheck
 script:
+  # TODO: After go 1.10 is released, below shell script is unnecessary:
+  # "Also, the go test -coverprofile option is now supported when running multiple tests."
+  # https://tip.golang.org/doc/go1.10#test
   - |
     echo "mode: count" > coverage.txt
     for pkg in $(go list ./... | grep -v /vendor/)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ install:
     - go get github.com/golang/lint/golint
     - go get honnef.co/go/tools/cmd/megacheck
 script:
-    - go test -v -race $(go list ./... | grep -v /vendor/)
+    - go test -v -race -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v /vendor/)
     - go vet $(go list ./... | grep -v /vendor/)
     - golint -set_exit_status $(go list ./... | grep -v /vendor/)
     - megacheck $(go list ./... | grep -v /vendor/)
-
+after_success:
+  - bash <(curl -s https://codecov.io/bash>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,29 @@
 language: go
 sudo: false
 go:
-    - 1.8.x
-    - 1.9.x
-    - tip
+  - 1.8.x
+  - 1.9.x
+  - tip
 
 before_install:
-    # Setup dependency management tool
-    - curl -L -s https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 -o $GOPATH/bin/dep
-    - chmod +x $GOPATH/bin/dep
+  # Setup dependency management tool
+  - curl -L -s https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 -o $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
 
 install:
-    - dep ensure
-    - go get github.com/golang/lint/golint
-    - go get honnef.co/go/tools/cmd/megacheck
+  - dep ensure
+  - go get github.com/golang/lint/golint
+  - go get honnef.co/go/tools/cmd/megacheck
 script:
-    - go test -v -race -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v /vendor/)
-    - go vet $(go list ./... | grep -v /vendor/)
-    - golint -set_exit_status $(go list ./... | grep -v /vendor/)
-    - megacheck $(go list ./... | grep -v /vendor/)
+  - |
+    echo "mode: count" > coverage.txt
+    for pkg in $(go list ./... | grep -v /vendor/)
+    do
+      go test -v -race -coverprofile=tmpcoverage.txt -covermode=atomic
+      tail -n +2 tmpcoverage.txt >> coverage.txt
+    done
+  - go vet $(go list ./... | grep -v /vendor/)
+  - golint -set_exit_status $(go list ./... | grep -v /vendor/)
+  - megacheck $(go list ./... | grep -v /vendor/)
 after_success:
   - bash <(curl -s https://codecov.io/bash>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Status](https://travis-ci.org/cceckman/discoirc.svg?branch=master)](https://travis-ci.org/cceckman/discoirc)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/cceckman/discoirc)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cceckman/discoirc)](https://goreportcard.com/report/github.com/cceckman/discoirc)
+[![codecov](https://codecov.io/gh/cceckman/discoirc/branch/master/graph/badge.svg)](https://codecov.io/gh/cceckman/discoirc)
 
 ```
         ||


### PR DESCRIPTION
Per title: use http://codecov.io to provide code coverage analysis during Travis builds.